### PR TITLE
Fixes for node v0.11 tests.

### DIFF
--- a/endpoints/car/index.js
+++ b/endpoints/car/index.js
@@ -1,5 +1,5 @@
 var request = require('request'),
-	$ = require('jquery'),
+	$ = require('cheerio'),
 	h = require('apis-helpers'),
 	app = require('../../server');
 

--- a/endpoints/company/index.js
+++ b/endpoints/company/index.js
@@ -1,11 +1,7 @@
 var request = require('request'),
-    $ = require('jquery'),
+    cheerio = require('cheerio'),
     h = require('apis-helpers'),
     app = require('../../server');
-
-$.fn.cleanHtml = function() {
-    return $.trim(this.html().replace(/<(?:.|\n)*?>/gm, ''));
-};
 
 app.get('/company', function(req, res, next){
     
@@ -26,33 +22,33 @@ app.get('/company', function(req, res, next){
         }
 
         var obj = { results: [] },
-            data = $(body);
+              $ = cheerio.load(body);
 
-        if(data.find('.resultnote').length == 0){
-            var tr = data.find('.boxbody > .nozebra tbody tr:first');
+        if($('.resultnote').length === 0){
+            var tr = $('.boxbody > .nozebra tbody tr').first();
             if (tr.length > 0) {
-                var name = data.find('.boxbody > h1').html(),
-                    sn = data.find('.boxbody > h1').html();
+                var name = $('.boxbody > h1').html(),
+                    sn = $('.boxbody > h1').html();
 
                 obj.results.push({
                     name: name.substring(0,name.indexOf('(')-1),
                     sn: sn.substring(sn.length-11,sn.length-1),
-                    active: data.find('p.highlight').text().length === 0 ? 1 : 0,
-                    address: tr.find('td').eq(0).cleanHtml()
+                    active: $('p.highlight').text().length === 0 ? 1 : 0,
+                    address: tr.find('td').eq(0).text()
                 });
             }
-        }else{
-            data.find('table tr:not(:first)').each(function() {
+        } else {
+            $('table tr').slice(1).each(function() {
 
                 var td = $(this).find('td');
-                var nameRoot = td.eq(1).cleanHtml();
+                var nameRoot = td.eq(1).text();
                 var felagAfskrad = "(Félag afskráð)";
 
                 obj.results.push({
                     name: nameRoot.replace("\n","").replace(felagAfskrad,"").replace(/^\s\s*/, '').replace(/\s\s*$/, ''),
-                    sn: td.eq(0).cleanHtml(),
+                    sn: td.eq(0).text(),
                     active: nameRoot.indexOf(felagAfskrad) > -1 ? 0 : 1,
-                    address: td.eq(2).cleanHtml()
+                    address: td.eq(2).text()
                 });
 
             }); 

--- a/endpoints/currency/m5.js
+++ b/endpoints/currency/m5.js
@@ -1,40 +1,40 @@
 var request = require('request'),
-	$ = require('jquery'),
-	h = require('apis-helpers'),
-	app = require('../../server');
+    h = require('apis-helpers'),
+    app = require('../../server'),
+    cheerio = require('cheerio');
 
 app.get('/currency/m5', function (req, res) {
-	var currencyNames = {
-		s: ['USD','DKK','EUR','JPY','CAD','NOK','GBP','CHF','SEK','TWI','XDR','ISK'],
-		l: ['Bandarískur dalur','Dönsk króna','Evra','Japanskt jen','Kanadískur dalur','Norsk króna','Sterlingspund','Svissneskur franki','Sænsk króna','Gengisvísitala','SDR','Íslensk króna']
-	};
+    var currencyNames = {
+        s: ['USD','DKK','EUR','JPY','CAD','NOK','GBP','CHF','SEK','TWI','XDR','ISK'],
+        l: ['Bandarískur dalur','Dönsk króna','Evra','Japanskt jen','Kanadískur dalur','Norsk króna','Sterlingspund','Svissneskur franki','Sænsk króna','Gengisvísitala','SDR','Íslensk króna']
+    };
 
-	request.get({
-		headers: { 'User-Agent': h.browser() },
-		url: 'http://www.m5.is/?gluggi=gjaldmidlar'
-	}, function(err, response, body) {
-		if(err || response.statusCode !== 200) {
-			return res.json(500,{error:'www.m5.is refuses to respond or give back data'});
-		}
+    request.get({
+        headers: { 'User-Agent': h.browser() },
+        url: 'http://www.m5.is/?gluggi=gjaldmidlar'
+    }, function(err, response, body) {
+        if(err || response.statusCode !== 200) {
+            return res.json(500,{error:'www.m5.is refuses to respond or give back data'});
+        }
 
-		var data = $(body),
-    	currencies = [];
+        var $ = cheerio.load(body),
+        currencies = [];
 
-		data.find('.table-striped tr').each(function () {
-			var tds = $(this).find('td'),
-        		name = tds.eq(0).text();
-      		
-      		name && currencies.push({
-				shortName: name,
-				longName: h.currency[name].long,
-				value: parseFloat(tds.eq(2).text().replace(',', '.')),
-				askValue: 0,
-				bidValue: 0,
-				changeCur: parseFloat(tds.eq(4).text().replace(',', '.')),
-				changePer: parseFloat(tds.eq(5).text().replace(/\((.*)%\)/, '$1').replace(',', '.'))
-			});
-		});
+        $('.table-striped tr').each(function () {
+            var tds = $(this).find('td'),
+                name = tds.eq(0).text();
+            
+            name && currencies.push({
+                shortName: name,
+                longName: h.currency[name].long,
+                value: parseFloat(tds.eq(2).text().replace(',', '.')),
+                askValue: 0,
+                bidValue: 0,
+                changeCur: parseFloat(tds.eq(4).text().replace(',', '.')),
+                changePer: parseFloat(tds.eq(5).text().replace(/\((.*)%\)/, '$1').replace(',', '.'))
+            });
+        });
 
-		return res.json({ results: currencies });
-	});
+        return res.json({ results: currencies });
+    });
 });

--- a/endpoints/flight/index.js
+++ b/endpoints/flight/index.js
@@ -1,81 +1,81 @@
 var request = require('request'),
-	$ = require('jquery'),
-	h = require('apis-helpers'),
-	app = require('../../server');
+    h = require('apis-helpers'),
+    app = require('../../server'),
+    cheerio = require('cheerio');
 
 app.get('/flight', function(req, res){
-	var data = req.query,
-		url = '';
+    var data = req.query,
+        url = '';
 
-	if(!data.type) data.type = '';
-	if(!data.language) data.language = '';
+    if(!data.type) data.type = '';
+    if(!data.language) data.language = '';
 
-	if(data.type == 'departures' && data.language == 'is'){
-		url = 'http://www.kefairport.is/Flugaaetlun/Brottfarir/';
-	}else if(data.type == 'departures' && data.language == 'en'){
-		url = 'http://www.kefairport.is/English/Timetables/Departures/';
-	}else if(data.type == 'arrivals' && data.language == 'is'){
-		url = 'http://www.kefairport.is/Flugaaetlun/Komur/';
-	}else if(data.type == 'arrivals' && data.language == 'en'){
-		url = 'http://www.kefairport.is/English/Timetables/Arrivals/';
-	}else{
-		url = 'http://www.kefairport.is/English/Timetables/Arrivals/';
-	}
+    if(data.type == 'departures' && data.language == 'is'){
+        url = 'http://www.kefairport.is/Flugaaetlun/Brottfarir/';
+    }else if(data.type == 'departures' && data.language == 'en'){
+        url = 'http://www.kefairport.is/English/Timetables/Departures/';
+    }else if(data.type == 'arrivals' && data.language == 'is'){
+        url = 'http://www.kefairport.is/Flugaaetlun/Komur/';
+    }else if(data.type == 'arrivals' && data.language == 'en'){
+        url = 'http://www.kefairport.is/English/Timetables/Arrivals/';
+    }else{
+        url = 'http://www.kefairport.is/English/Timetables/Arrivals/';
+    }
 
-	request.get({
-		headers: {'User-Agent': h.browser()},
-		url: url
-	}, function(error, response, body){
-		if(error || response.statusCode !== 200)
-			return res.json(500,{error:'www.kefairport.is refuses to respond or give back data'});
+    request.get({
+        headers: {'User-Agent': h.browser()},
+        url: url
+    }, function(error, response, body){
+        if(error || response.statusCode !== 200)
+            return res.json(500,{error:'www.kefairport.is refuses to respond or give back data'});
 
-		try{
-			var data = $(body);	
-		}catch(error){
-			return res.json(500,{error:'Could not parse body'});
-		}
+        try {
+          var $ = cheerio.load(body);   
+        } catch(err) {
+            return res.json(500,{error:'Could not parse body'});
+        }
 
-		var	obj = { results: []};
+        var obj = { results: []};
 
-		var fields = ['date','flightNumber','airline','to','from','plannedArrival','realArrival','status'];
-		
-		data.find('table tr').each(function(key){
-			if(key !== 0){
-				var flight = {};
-				if(data.type === 'departures') {
-					flight = {
-						'date': '',
-						'flightNumber':'',
-						'airline':'',
-						'to': '',
-						'plannedArrival': '',
-						'realArrival': '',
-						'status': ''
-					}
-				}
-				else {
-					flight = {
-						'date': '',
-						'flightNumber':'',
-						'airline':'',
-						'from': '',
-						'plannedArrival': '',
-						'realArrival': '',
-						'status': ''
-					}
-				}
-				
-				$(this).find('td').each(function(key){
-					var val = $(this).html();
-					if(val != '' && val != 0){ // Perform check and add to flight array if it passes
-						flight[fields[key]] = val;
+        var fields = ['date','flightNumber','airline','to','from','plannedArrival','realArrival','status'];
+        
+        $('table tr').each(function(key){
+            if(key !== 0){
+                var flight = {};
+                if(data.type === 'departures') {
+                    flight = {
+                        'date': '',
+                        'flightNumber':'',
+                        'airline':'',
+                        'to': '',
+                        'plannedArrival': '',
+                        'realArrival': '',
+                        'status': ''
+                    }
+                }
+                else {
+                    flight = {
+                        'date': '',
+                        'flightNumber':'',
+                        'airline':'',
+                        'from': '',
+                        'plannedArrival': '',
+                        'realArrival': '',
+                        'status': ''
+                    }
+                }
+                
+                $(this).find('td').each(function(key){
+                    var val = $(this).html();
+                    if(val != '' && val != 0){ // Perform check and add to flight array if it passes
+                        flight[fields[key]] = val;
 
-					}
-				});
-				obj.results.push(flight);
-			}
-		});
-		
-		return res.cache(3600).json(obj);
-	});
+                    }
+                });
+                obj.results.push(flight);
+            }
+        });
+        
+        return res.cache(3600).json(obj);
+    });
 });

--- a/endpoints/lottery/index.js
+++ b/endpoints/lottery/index.js
@@ -1,6 +1,6 @@
 var request = require('request'),
-    $ = require('jquery'),
-    app = require('../../server');
+    app = require('../../server'),
+    cheerio = require('cheerio');
 
 
 var getLotto = function (req, res) {
@@ -48,17 +48,15 @@ var getLottery = function(callback, url) {
 };
 
 var parseList = function ( body ) {
-	var site;
-
 	try {
-		site = $(body);
+		var $ = cheerio.load(body);
 	} catch(error) {
 		throw new Error("Could not parse body");
 	}
 
     var results = [];
 
-    var tr = site.find('table').eq(1).find('tr');
+    var tr = $('table').eq(1).find('tr');
 
     tr.each(function (i) {
         if ( i === 0 ) return;

--- a/endpoints/names/index.js
+++ b/endpoints/names/index.js
@@ -6,9 +6,9 @@ Created: August 2014
 */
 
 var request = require('request'),
-	$ = require('jquery'),
 	h = require('apis-helpers'),
-	app = require('../../server');
+	app = require('../../server'),
+    cheerio = require('cheerio');
 
 /* Root names handler - only returns a list of resources */
 app.get('/names', function (req, res) {
@@ -87,9 +87,8 @@ function handleRequest(url, req, res) {
 		if(error || response.statusCode !== 200)
 			return res.json(500,{error:'www.island.is refuses to respond or give back data'});
 
-    var data;
 		try{
-			data = $(body);	
+			var $ = cheerio.load(body);	
 		}catch(error){
 			return res.json(500,{error:'Could not parse body'});
 		}
@@ -97,12 +96,12 @@ function handleRequest(url, req, res) {
 		var	obj = { results: []};
 		
 		// Clear data regarding the acceptance date of the name (not needed)
-		data.find('.dir li i').each(function(key) {
+		$('.dir li i').each(function(key) {
 			$(this).remove();
 		});
 
 		// Loop through all the names in the list and add them to our array
-		data.find('.dir li').each(function(key){
+		$('.dir li').each(function(key){
 			var name = $(this).text();
 			obj.results.push(name.trim());
 		});

--- a/endpoints/sarschool/index.js
+++ b/endpoints/sarschool/index.js
@@ -1,6 +1,6 @@
 var request = require('request'),
-    $ = require('jquery'),
-    app = require('../../server');
+    app = require('../../server'),
+    cheerio = require('cheerio');
 
 String.prototype.replaceArray = function(find, replace) {
   var replaceString = this;
@@ -42,10 +42,9 @@ var getRequest = function(callback, url) {
 };
 
 var parseList = function ( body ) {
-	var site;
 
 	try {
-		site = $(body);
+		var $ = cheerio.load(body);
 	} catch(error) {
 		throw new Error("Could not parse body");
 	}
@@ -53,7 +52,7 @@ var parseList = function ( body ) {
     var results = [];
     
 
-    var tr = site.find('.rgMasterTable').find('tbody').find('tr');
+    var tr = $('.rgMasterTable').find('tbody').find('tr');
 
     tr.each(function (i) {
         var td = $(this).find('td');
@@ -87,7 +86,7 @@ var parseList = function ( body ) {
              time_start: start_date_final,
              time_end: end_date_final,
              sar_members_only: (td.eq(0).find('img').length > 0 ? 1:0),
-             host: (td.eq(5).find('input').prop('checked')?'Squad':'Other'),
+             host: (td.eq(5).find('input').attr('checked') == 'checked' ? 'Squad' : 'Other'),
              location: (td.eq(8).text().trim()==""?"":td.eq(8).text().trim()),
              price_regular: (td.eq(9).text().trim()==""?"":parseFloat(td.eq(9).text().trim().replace(".",""))),
              price_members: (td.eq(10).text().trim()==""?"":parseFloat(td.eq(10).text().trim().replace(".",""))),

--- a/endpoints/sports/index.js
+++ b/endpoints/sports/index.js
@@ -4,17 +4,11 @@
  * Created:  March 2014
  */
 
-var request, parseString, h, app, cheerio;
-
-/** Requires **/
-request = require('request'),
-parseString = require('xml2js').parseString,
-h = require('apis-helpers'),
-app = require('../../server'),
-cheerio = require('cheerio'),
-$ = require('jquery'),
-
-/** Variable initialization **/
+var request = require('request');
+var parseString = require('xml2js').parseString;
+var h = require('apis-helpers');
+var app = require('../../server');
+var cheerio = require('cheerio');
 
 /* Fetches the sports data and returns a JS object in a callback */
 function getJsonData(url, callback){
@@ -61,8 +55,10 @@ app.get('/sports/football', function (req, res) {
         return res.json(500,{error:'www.ksi.is refuses to respond or give back data'});
       }
 
+      var $;
+
       try {
-        var data = $(body);	
+        $ = cheerio.load(body);	
       } catch(error) {
         return res.json(500,{error:'Could not parse body'});
       }
@@ -70,7 +66,7 @@ app.get('/sports/football', function (req, res) {
       var obj = { results: []};
       var fields = ['counter','date','time','tournament', 'location', 'homeTeam', 'awayTeam'];
       try {
-        data.find('#leikir-tafla tr').not(':first').each(function(key) {
+        $('#leikir-tafla tr').not(':first').each(function(key) {
           if (key !== 0) {
             var game = {};
         	  $(this.cells).each(function(key2) {
@@ -102,7 +98,7 @@ app.get('/sports/handball', function (req, res) {
       }
 
       try {
-        var data = $(body);
+        var $ = cheerio.load(body);
       } catch(error) {
         return res.json(500, {error:'Could not parse body'});
       }
@@ -111,7 +107,7 @@ app.get('/sports/handball', function (req, res) {
       var fields = ['Date', 'Time', 'Tournament', 'Venue', 'Teams'];
 
       try {
-        data.find('table').eq(1).find('tr').not(':first').each(function(key) {
+        $('table').eq(1).find('tr').not(':first').each(function(key) {
           if (key !== 0) {
             var game = {};
             $(this.cells).each(function(key2) {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,6 @@
     "moment": "~2.1.0",
     "xml2js": "~0.2.8",
     "request": "~2.27.0",
-    "scraper": "0.0.9",
-    "jquery": "~1.8.3",
     "redis": "~0.8.4",
     "xregexp": "~2.0.0",
     "cheerio": "~0.12.4",


### PR DESCRIPTION
When you cannot sleep, make software.

This deprcates `node-jquery` for `cheerio`. No need to have both and `node-jquery` relies on jsdom which doesn't have a node v0.11 package.

Fixes #149.