### PR TITLE
Clearer & cleaner logic of chosing port to listen to

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var cors = require('cors');
 
 var endpoints = fs.readdirSync(__dirname + '/endpoints/');
 
-app.set('port', config.get('port'));
+app.set('port', process.env.PORT || config.get('port'));
 
 var uptime = new Date().getTime();
 app.get('/uptime', function(req, res) {
@@ -103,9 +103,8 @@ app.use(function(err, req, res, next) {
  * Start the server
  */
 if (!module.parent) {
-  var port = process.env.PORT || config.get('port');
-  app.listen(port, function () {
-    console.log('Listening on port',port);
+  app.listen(app.get('port'), function () {
+    console.log('Listening on port', app.get('port'));
   });
 }
 


### PR DESCRIPTION
Minor change. The result is the same as before, `process.env.PORT || config.get('port')`, it's just clearer and easier to understand.