### PR TITLE
Remove roadmap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,3 @@ gulp watch
 ```
 
 Now gulp will be running express in the background restarting it, rebuilding all code and running tests when any change is detected.
-
-## Roadmap to APIs 2.0
-
-- APIs 2.0 [#80](https://github.com/kristjanmik/apis/issues/80)
-- Caching headers mentioned in [#74](https://github.com/kristjanmik/apis/issues/74)
-- Version handling [#18](https://github.com/kristjanmik/apis/issues/18)
-- Implement jshintrc and/or similar tools [#103](https://github.com/kristjanmik/apis/issues/103)
-- Code linting and beautification [#77](https://github.com/kristjanmik/apis/issues/77)
-- status.apis.is - display endpoint status/uptime etc. [#117](https://github.com/kristjanmik/apis/issues/117)
-- Implement version control for endpoints [#119](https://github.com/kristjanmik/apis/issues/119)
-- Describe how to create new endpoints [#120](https://github.com/kristjanmik/apis/issues/120)
-- Logo for the APIs project [#121](https://github.com/kristjanmik/apis/issues/121)


### PR DESCRIPTION
I think we should remove the roadmap. Most of the stuff on there is done or in process. Instead we should rather just file issues on github for stuff that needs to get done and add a `2.0` label.

What do you think? 